### PR TITLE
Fix: Add theme persistence to localStorage

### DIFF
--- a/src/components/ToggleTheme.jsx
+++ b/src/components/ToggleTheme.jsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from "react";
 
 function ToggleTheme() {
-  const [theme, setTheme] = useState('auto');
+  const [theme, setTheme] = useState(() => {
+    const savedTheme = localStorage.getItem('theme');
+    return savedTheme || 'auto';
+  });
   const themeAuto = () => 
     (<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" stroke-width="1.25"> <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path> <path d="M12 3l0 18"></path> <path d="M12 9l4.65 -4.65"></path> <path d="M12 14.3l7.37 -7.37"></path> <path d="M12 19.6l8.85 -8.85"></path> </svg>)
 
@@ -13,6 +16,7 @@ function ToggleTheme() {
     } else {
       root.setAttribute('data-theme', theme);
     }
+    localStorage.setItem('theme', theme);
   }, [theme]);
 
   const toggleTheme = () => {


### PR DESCRIPTION
## Summary
- Load saved theme preference from localStorage on component mount
- Save theme preference to localStorage whenever it changes
- Closes #3

## Test plan
- [x] Toggle between auto/light/dark themes
- [x] Refresh the page and verify theme persists
- [x] Clear localStorage and verify default 'auto' theme is used

🤖 Generated with [Claude Code](https://claude.ai/code)